### PR TITLE
Fixes CI badge status for each role.

### DIFF
--- a/roles/awscliv2/README.md
+++ b/roles/awscliv2/README.md
@@ -1,7 +1,7 @@
 Ansible Role: awscliv2
 =========
 
-[![AWSCLIV2CI](https://github.com/steffkelsey/linux-laptop/actions/workflows/awscliv2-ci.yml/badge.svg?branch=master)](https://github.com/steffkelsey/linux-laptop/actions/workflows/awscliv2-ci.yml)
+[![AWSCLIV2CI](https://github.com/steffkelsey/linux-laptop/actions/workflows/awscliv2-ci.yml/badge.svg?branch=main)](https://github.com/steffkelsey/linux-laptop/actions/workflows/awscliv2-ci.yml)
 
 Installs AWS CLI v2 on Debian.
 

--- a/roles/go_dev/README.md
+++ b/roles/go_dev/README.md
@@ -1,7 +1,7 @@
 Ansible Role: go_dev
 =========
 
-[![GODEV2CI](https://github.com/steffkelsey/linux-laptop/actions/workflows/go-dev-ci.yml/badge.svg?branch=master)](https://github.com/steffkelsey/linux-laptop/actions/workflows/go-dev-ci.yml)
+[![GODEV2CI](https://github.com/steffkelsey/linux-laptop/actions/workflows/go-dev-ci.yml/badge.svg?branch=main)](https://github.com/steffkelsey/linux-laptop/actions/workflows/go-dev-ci.yml)
 
 Installs Golang on Debian.
 


### PR DESCRIPTION
Each role has it's own README.md file where the status on the CI badges
was incorrectly pointing to the deprecated `master` branch. This updates
both of them to point at the `main` branch, mirroring the code from the
README.md at the project root.