### PR TITLE
Fixes usage of ansible_facts. Removes references to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Second, install the dependencies for the main playbook and the roles.
 
 To provision all the roles in this repo for the entire linux-laptop, navigate
 to the root directory of this repo and run:  
-`$ ansible-playbook main.yml --extra-vars=asdf_user=$(whoami) --ask-become-pass`
+`$ ansible-playbook main.yml --ask-become-pass --extra-vars "asdf_user=$(whoami)"`
 
 The `asdf_user` variable is required for asdf to work since it operates out of
 the home directory.

--- a/roles/go_dev/tasks/main.yml
+++ b/roles/go_dev/tasks/main.yml
@@ -6,7 +6,6 @@
 
 - name: "go_dev | Run task that installs go"
   include_tasks: install.yml
-  # yamllint disable-line rule:line-length
   when: >
     not go_binary.stat.exists or
     current_go_version is not defined or

--- a/roles/go_dev/tasks/setup.yml
+++ b/roles/go_dev/tasks/setup.yml
@@ -10,16 +10,16 @@
 - name: "go_dev | Define go_arch amd64"
   set_fact:
     go_arch: "amd64"
-  when: go_arch is not defined and ansible_architecture == "x86_64"
+  when:
+    - go_arch is not defined
+    - ansible_facts['architecture'] == "x86_64"
 
-# We wouldn't need this except for apple M1 (which would be arm64 when
-# everything else is amd64) If someone is running in Intel mode emulation, we
-# just won't be able to tell. It's possible we could get more using
-# ansible_processor, but I don't have a mac to test on atm.
 - name: "go_dev | Define go_arch arm64"
   set_fact:
     go_arch: "arm64"
-  when: go_arch is not defined and ansible_architecture == "arm64"
+  when:
+    - go_arch is not defined
+    - ansible_facts['architecture'] == "arm64"
 
 - name: "go_dev | Define version comparison string"
   set_fact:
@@ -31,22 +31,24 @@
     go_os: "linux"
   when:
     - go_os is not defined
-    - ansible_distribution != "Darwin"
-    - ansible_distribution != "FreeBSD"
+    - ansible_facts['distribution'] != "Darwin"
+    - ansible_facts['distribution'] != "FreeBSD"
 
-# Once again for macOS machines - assuming that the ansible_distribution fact
-# is correct for us.
 - name: "go_dev | Define go_os darwin"
   set_fact:
     go_os: "darwin"
-  when: go_os is not defined and ansible_distribution == "Darwin"
+  when:
+    - go_os is not defined
+    - ansible_facts['distribution'] == "Darwin"
 
 # prob don't need to cover the FreeBSD case, but why not? Looking at the Go
 # downloads page and didn't want to leave it.
 - name: "go_dev | Define go_os freebsd"
   set_fact:
     go_os: "freebsd"
-  when: go_os is not defined and ansible_distribution == "FreeBSD"
+  when:
+    - go_os is not defined
+    - ansible_facts['distribution'] == "FreeBSD"
 
 - name: "go_dev | Define URL for download from go developer site"
   set_fact:


### PR DESCRIPTION
I was using ansible_facts wrong. For example, when fetching the arch,
the correct way is to use `ansible_facts['architecture']` and I was
using `ansible_architecture` which is deprecated. And the calls to
`ansible_distrubition` were always returning empty. This is now fixed.

I also removed all references to macOS because 1) this is a linux
playbook and 2) the claims I was making were wrong. In GitHub actions,
the `ansible_facts['distribution']` was coming back as `MacOSX` and not
`Darwin` as I had thought. And that stuff is better documented in the
repo for the multi-os-dev proof of concept - no need to say anything
about it in the comments of this code.

Also fixes a typo in the README about using `--extra-vars`