### PR TITLE
Fixes the idempotence step on the legacy_installed scenario

### DIFF
--- a/roles/awscliv2/molecule/legacy_installed/converge.yml
+++ b/roles/awscliv2/molecule/legacy_installed/converge.yml
@@ -3,13 +3,5 @@
   hosts: all
   tasks:
 
-    # The setup scenario installs an older version
     - name: "Setup Scenario"
       include_tasks: "../common/tasks/setup.yml"
-
-    - name: "Run the role again with newer version"
-      include_role:
-        name: "awscliv2"
-      vars:
-        awscliv2_version: "{{ newer_awscliv2_version }}"
-        awscliv2_apt_cache_update: false

--- a/roles/awscliv2/molecule/legacy_installed/molecule.yml
+++ b/roles/awscliv2/molecule/legacy_installed/molecule.yml
@@ -15,13 +15,3 @@ lint: |
   set -e
   yamllint .
   ansible-lint
-scenario:
-  test_sequence:
-    - lint
-    - destroy
-    - dependency
-    - syntax
-    - create
-    - converge
-    - verify
-    - destroy

--- a/roles/awscliv2/molecule/legacy_installed/prepare.yml
+++ b/roles/awscliv2/molecule/legacy_installed/prepare.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+
+    - name: Load scenario variables
+      include_vars: vars/main.yml
+
+    - name: "Run the role installing an old version"
+      include_role:
+        name: "awscliv2"
+      vars:
+        awscliv2_version: "{{ older_awscliv2_version }}"

--- a/roles/awscliv2/molecule/legacy_installed/vars/main.yml
+++ b/roles/awscliv2/molecule/legacy_installed/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # lookup versions here: https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
-newer_awscliv2_version: 2.4.16
-awscliv2_version: 2.4.12
+older_awscliv2_version: 2.4.12
+awscliv2_version: 2.4.16
 awscliv2_clean: false
 # has to be true because apt update has never been run before
 awscliv2_apt_cache_update: true

--- a/roles/awscliv2/molecule/legacy_installed/verify.yml
+++ b/roles/awscliv2/molecule/legacy_installed/verify.yml
@@ -22,4 +22,4 @@
 
   - name: Assert that the installed version matches the target
     assert:
-      that: newer_awscliv2_version == aws_version_to_verify
+      that: awscliv2_version == aws_version_to_verify


### PR DESCRIPTION
I had trimmed out the idempotence check on the awscliv2 legacy_installed scenario because i was doing all the setup in the converge phase (what an idiot!).

This PR moves the setup into the aptly named prepare.yml file which is run once and only once before all the other tests run in order to "prepare" to run the tests. I think since no other scenarios were using a prepare.yml and i deleted them, I just forgot that the phase existed. But I needed it!

And now it is back and I am running the default sequence on the scenario and we can march forward with confidence that things are working properly when it comes to awscliv2 upgrading from an older version.