### PR TITLE
Fixes broken CI by using specific versions of linters

### DIFF
--- a/.github/workflows/awscliv2-ci.yml
+++ b/.github/workflows/awscliv2-ci.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] yamllint ansible-lint
+        run: pip3 install ansible==5.4.0 molecule[docker,lint]==3.6.1 yamllint==1.26.3 ansible-lint==5.4.0
 
       - name: Run Molecule tests.
         run: molecule test -s "${SCENARIO}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] yamllint ansible-lint
+        run: pip3 install ansible==5.4.0 molecule[docker,lint]==3.6.1 yamllint==1.26.3 ansible-lint==5.4.0
 
       - name: Setup test environment.
         run: ansible-galaxy install -r requirements.yml

--- a/.github/workflows/go-dev-ci.yml
+++ b/.github/workflows/go-dev-ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] yamllint ansible-lint
+        run: pip3 install ansible==5.4.0 molecule[docker,lint]==3.6.1 yamllint==1.26.3 ansible-lint==5.4.0
 
       - name: Run Molecule tests.
         run: molecule test

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -12,8 +12,7 @@ if [ "$id" == "Ubuntu" ]; then
   # ubuntu setup
   sudo apt-get update
   sudo apt-get install python3.8 python3-pip libssl-dev
-  # TODO - switch to using virtualenv rather than a global install
-  python3 -m pip install ansible molecule[docker,lint] yamllint ansible-lint
+  python3 -m pip install -r requirements.txt
 else
   echo "Not setup for distro: $id"
   echo "EXITING WITHOUT INSTALLING ANSIBLE"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ansible==5.4.0
+molecule[docker,lint]==3.6.1
+yamllint==1.26.3
+ansible-lint==5.4.0


### PR DESCRIPTION
A naive approach just to see if I can force the versions of molecule,
ansible, and the linters to be something specific. Just going with the
latest introduced breaking changes where the code didn't change in the
repo.

A better approach would be to use the same requirements.txt file for
installing the dependencies locally as what is used to install the
dependencies in the GitHub Action workflows. But, that seems more
involved so I am punting on that until I have time to mess with a global
requirements.txt file. I am just not sure how to tell GitHub workflows
on where to pickup the file.