### PR TITLE
Removes ruby install

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -8,7 +8,6 @@
     install_awscliv2: true
     install_docker: true
     install_nodejs: true
-    install_ruby: true
     install_asdf: true
 
   pre_tasks:
@@ -74,16 +73,6 @@
         nodejs_version: "18.x"
         nodejs_npm_global_packages:
           - name: yarn
-
-    - name: linux-laptop | Maybe install ruby
-      include_role:
-        name: geerlingguy.ruby
-      when: install_ruby
-      vars:
-        ruby_version: 2.7.7
-        ruby_download_url: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.gz
-        ruby_install_from_source: true
-        ruby_install_bundler: true
 
     - name: linux-laptop | Maybe install docker
       include_role:

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,5 @@ roles:
     version: 6.0.4
   - name: geerlingguy.nodejs
     version: 6.1.1
-  - name: geerlingguy.ruby
-    version: 3.2.0
   - name: baztian.asdf
     version: v0.0.4


### PR DESCRIPTION
The Ruby install ended up being a sudo install where all bundle commands etc had to be executed with sudo and it just didn't work. I used that molecule module instead of installing rvm because i didn't think Rubymine would behanve well with rvm, but it ends up it has first class support for rvm. So yeah, fucked it on that one.