### PR TITLE
Fixes bashrc issues

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Configure Linux dev machine
   hosts: all
-  become: true
 
   vars_files:
     - default.config.yml

--- a/main.yml
+++ b/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Configure Linux dev machine
   hosts: all
+  become: true
 
   vars_files:
     - default.config.yml

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -1,7 +1,8 @@
 ---
-- name: linux-dev | Edit .bash_profile to load the dotfiles
+- name: linux-dev | Edit .bashrc to load the dotfiles
+  become: false
   ansible.builtin.blockinfile:
-    path: '{{ ansible_env.HOME }}/.bash_profile'
+    path: '~/.bashrc'
     marker: "# {mark} ALIASES AND PROMPT"
     block: |
       # import the aliases
@@ -9,9 +10,10 @@
       # set the custom prompt
       . ~/.bash_prompt
 
-- name: linux-dev | Edit .bash_profile for shell before
+- name: linux-dev | Edit .bashrc for shell before
+  become: false
   ansible.builtin.blockinfile:
-    path: '{{ ansible_env.HOME }}/.bash_profile'
+    path: '~/.bashrc'
     insertbefore: BOF
     marker: "# {mark} SHELL BEFORE"
     block: |
@@ -20,9 +22,10 @@
         . ~/.shell_local_before
       fi 
 
-- name: linux-dev | Edit .bash_profile for shell after
+- name: linux-dev | Edit .bashrc for shell after
+  become: false
   ansible.builtin.blockinfile:
-    path: '{{ ansible_env.HOME }}/.bash_profile'
+    path: '~/.bashrc'
     insertafter: EOF
     marker: "# {mark} SHELL AFTER"
     block: |

--- a/tasks/tpm.yml
+++ b/tasks/tpm.yml
@@ -1,6 +1,7 @@
 ---
-- name: linux-dev | Clone tpm to $HOME/.tmux/plugins/tpm
+- name: linux-dev | Clone tpm to ~/.tmux/plugins/tpm
+  become: false
   ansible.builtin.git:
     repo: "https://github.com/tmux-plugins/tpm"
-    dest: '{{ ansible_env.HOME }}/.tmux/plugins/tpm'
+    dest: '~/.tmux/plugins/tpm'
     single_branch: yes

--- a/tasks/vimplug.yml
+++ b/tasks/vimplug.yml
@@ -1,12 +1,14 @@
 ---
 - name: linux-dev | Create ~/.vim/autoload directory
+  become: false
   ansible.builtin.file:
-    path: '{{ ansible_env.HOME }}/.vim/autoload'
+    path: '~/.vim/autoload'
     state: directory
     mode: "0755"
 
 - name: linux-dev | Download vim-plug/plug.vim file to ~/.vim/autoload/plug.vim
+  become: false
   ansible.builtin.get_url:
     url: "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
-    dest: '{{ ansible_env.HOME }}/.vim/autoload/plug.vim'
+    dest: '~/.vim/autoload/plug.vim'
     mode: "0644"


### PR DESCRIPTION
The dotfiles were not connecting correctly when the playbook was run locally using --ask-become-pass. AND changing .bash_profile is actually folly since it only affects the login shell which is not what is used when I fire up a gnome-terminal on Rocky. Moved the file edits to bashrc.

Tested in molecule and running ansible-playbook locally.