### PR TITLE
Updates .bashrc edits to include mise activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ source .venv/bin/activate
 # (optional) update pip to the latest
 pip3 install --upgrade pip
 # Install everything from the requirements file
-pip3 install -f requirements.txt
+pip3 install -r requirements.txt
 
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+python = "3.12"

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -3,7 +3,7 @@
   become: false
   ansible.builtin.blockinfile:
     path: '~/.bashrc'
-    marker: "# {mark} ALIASES AND PROMPT"
+    marker: "# {mark} ALIASES AND PROMPT (ANSIBLE)"
     block: |
       # import the aliases
       . ~/.aliases.bash
@@ -15,7 +15,7 @@
   ansible.builtin.blockinfile:
     path: '~/.bashrc'
     insertbefore: BOF
-    marker: "# {mark} SHELL BEFORE"
+    marker: "# {mark} SHELL BEFORE (ANSIBLE)"
     block: |
       # Allow local customizations in the ~/.shell_local_before file
       if [ -f ~/.shell_local_before ]; then
@@ -27,12 +27,19 @@
   ansible.builtin.blockinfile:
     path: '~/.bashrc'
     insertafter: EOF
-    marker: "# {mark} SHELL AFTER"
+    marker: "# {mark} SHELL AFTER (ANSIBLE)"
     block: |
       # Allow local customizations in the ~/.shell_local_after file
       if [ -f ~/.shell_local_after ]; then
         . ~/.shell_local_after
       fi 
+
+- name: linux-dev | Debug env vars
+  become: false
+  ansible.builtin.debug:
+    msg: "dotfiles_repo_ssh: {{ dotfiles_repo_ssh }}, block_this: {{ block_this }}, BLOCK_REMOTE_SET_URL_SSH: {{ lookup('ansible.builtin.env','BLOCK_REMOTE_SET_URL_SSH', default='false') }}"
+  vars:
+    block_this: "{{ lookup('ansible.builtin.env', 'BLOCK_REMOTE_SET_URL_SSH', default='false') }}"
 
 - name: linux-dev | Maybe change remote url to ssh
   become: false
@@ -45,4 +52,4 @@
     block_this: "{{ lookup('ansible.builtin.env', 'BLOCK_REMOTE_SET_URL_SSH', default='false') }}"
   when: 
     - dotfiles_repo_ssh
-    - not block_this
+    - not (block_this | bool)

--- a/tasks/mise.yml
+++ b/tasks/mise.yml
@@ -11,3 +11,11 @@
   ansible.builtin.package:
     name: mise
     state: present
+
+- name: linux-dev | Edit .bashrc for mise activation
+  become: false
+  ansible.builtin.blockinfile:
+    path: '~/.bashrc'
+    marker: '# {mark} MISE ACTIVATION (ANSIBLE)'
+    block: |
+      eval "$(/usr/bin/mise activate bash)"


### PR DESCRIPTION
Adds a debug line for the dotfiles repo switching to an ssh remote url. Cleans up an error in the README file about installing dependencies with pip.
Adds a local mise.toml for the python version - I had blown up my local env by removing PyEnv in favor of managing python versions with mise and this addresses the change to managing the project python version rather than a global python version.